### PR TITLE
Fix constant popup about resuming running timers with Alfred 4

### DIFF
--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -7,7 +7,7 @@ shopt -s expand_aliases
 alias growlnotify='/usr/local/bin/growlnotify EggTimer --image icon.png -m '
 
 #Working directories
-EGGPREFS="$HOME/Library/Application Support/Alfred 3/Workflow Data/carlosnz.eggtimer2"
-EGGWD="$HOME/Library/Caches/com.runningwithcrayons.Alfred-3/Workflow Data/carlosnz.eggtimer2"
+EGGPREFS="$HOME/Library/Application Support/Alfred/Workflow Data/carlosnz.eggtimer2"
+EGGWD="$HOME/Library/Caches/com.runningwithcrayons.Alfred-4/Workflow Data/carlosnz.eggtimer2"
 
 wfdir=$PWD		#Get workflow directory


### PR DESCRIPTION
I tried using this on Alfred 4 but kept getting the popup saying "Would you like EggTimer to resume your running timers when you log back in to your computer after a restart?".

Fixed by updating `includes.sh` to point towards Alfred 4's new preferences directory.